### PR TITLE
Fix missed copying of package.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ ENV PORT 8080
 ENV NODE_ENV=production
 WORKDIR /app
 
-COPY . .
+COPY ["package.json", "package-lock.json*", "./"]
 RUN npm install --production
+
+COPY . .
 
 CMD [ "node", "server.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,7 @@ ENV PORT 8080
 ENV NODE_ENV=production
 WORKDIR /app
 
-COPY ["package.json", "package-lock.json*"]
-RUN npm install --production
-
 COPY . .
+RUN npm install --production
 
 CMD [ "node", "server.js" ]


### PR DESCRIPTION
The Dockerfile was failing to copy `package.json`, resulting in

```
internal/modules/cjs/loader.js:883
  throw err;
  ^

Error: Cannot find module 'express'
Require stack:
- /app/server.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
    at Function.Module._load (internal/modules/cjs/loader.js:725:27)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (/app/server.js:1:15)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/app/server.js' ]
}```

The `CP` lines were wrong in `Dockerfile`. Do you agree?